### PR TITLE
Add question analysis tests and improve illness detection

### DIFF
--- a/horary78-main/horary77-main/horary4/backend/question_analysis.py
+++ b/horary78-main/horary77-main/horary4/backend/question_analysis.py
@@ -31,7 +31,7 @@ class TraditionalHoraryQuestionAnalyzer:
             "travel": ["journey", "travel", "trip", "go to", "visit"],
             "money": ["money", "wealth", "rich", "profit", "gain", "debt"],
             "career": ["job", "career", "work", "employment", "business"],
-            "health": ["sick", "illness", "disease", "health", "recover", "die"],
+            "health": ["sick", "ill", "illness", "disease", "health", "recover", "die"],
             "lawsuit": ["court", "lawsuit", "legal", "judge", "trial"],
             "relationship": ["love", "relationship", "friend", "enemy"]
         }
@@ -93,14 +93,15 @@ class TraditionalHoraryQuestionAnalyzer:
         
         # ------------- detect key themes ---------------
         death_words = ["die", "death", "pass away", "funeral"]
-        illness_words = ["sick", "illness", "disease", "recover"]
+        illness_words = ["sick", "ill", "illness", "disease", "recover"]
         
         if subject_house is not None:
             if any(w in question_lower for w in death_words):
                 houses.append(self._turn(subject_house, 8))  # 8th from subject
                 houses.append(subject_house)
             elif any(w in question_lower for w in illness_words):
-                houses.append(self._turn(subject_house, 6))  # 6th from subject
+                # Illness of a known person: 6th house of illness and the person's house
+                houses.append(6)
                 houses.append(subject_house)
             else:
                 houses.append(subject_house)

--- a/tests/test_question_analysis.py
+++ b/tests/test_question_analysis.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+# Add backend module path for importing TraditionalHoraryQuestionAnalyzer
+BASE_DIR = Path(__file__).resolve().parent.parent
+sys.path.append(str(BASE_DIR / "horary78-main" / "horary77-main" / "horary4" / "backend"))
+
+from question_analysis import TraditionalHoraryQuestionAnalyzer
+
+analyzer = TraditionalHoraryQuestionAnalyzer()
+
+def test_lost_item_analysis():
+    result = analyzer.analyze_question("Where is my ring?")
+    assert result["question_type"] == "lost_object"
+    assert result["relevant_houses"] == [1, 2]
+    assert result["significators"] == {
+        "querent_house": 1,
+        "quesited_house": 2,
+        "moon_role": "co-significator of querent and general flow",
+        "special_significators": {},
+    }
+
+def test_marriage_analysis():
+    result = analyzer.analyze_question("Will I marry soon?")
+    assert result["question_type"] == "marriage"
+    assert result["relevant_houses"] == [1, 7]
+    assert result["significators"] == {
+        "querent_house": 1,
+        "quesited_house": 7,
+        "moon_role": "co-significator of querent and general flow",
+        "special_significators": {
+            "venus": "natural significator of love",
+            "mars": "natural significator of men",
+        },
+    }
+
+def test_ill_relative_analysis():
+    result = analyzer.analyze_question("Is my father ill?")
+    assert result["question_type"] == "health"
+    assert result["relevant_houses"] == [1, 6, 4]
+    assert result["significators"] == {
+        "querent_house": 1,
+        "quesited_house": 6,
+        "moon_role": "co-significator of querent and general flow",
+        "special_significators": {
+            "mars": "fever and inflammation",
+            "saturn": "chronic illness",
+        },
+    }


### PR DESCRIPTION
## Summary
- add unit tests for TraditionalHoraryQuestionAnalyzer
- treat "ill" as a health keyword and correctly identify illness of a known person

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dd72fe3408324a068429ed21b0e10